### PR TITLE
fix: crash on cast from float to float in reshade shaders

### DIFF
--- a/src/reshade/effect_codegen_spirv.cpp
+++ b/src/reshade/effect_codegen_spirv.cpp
@@ -1138,7 +1138,7 @@ private:
 						.add(emit_constant(op.from, 0))
 						.result;
 				}
-				else
+				else if (op.to != op.from)
 				{
 					spv::Op spv_op = spv::OpNop;
 


### PR DESCRIPTION
Allow redudant cast by not generation instructions for it.

original pull request
https://github.com/DadSchoorse/vkBasalt/pull/243